### PR TITLE
Fixes empty image on first frame

### DIFF
--- a/lib/src/crop.dart
+++ b/lib/src/crop.dart
@@ -241,6 +241,7 @@ class CropState extends State<Crop> with TickerProviderStateMixin, Drag {
         );
       });
     });
+    WidgetsBinding.instance.ensureVisualUpdate();
   }
 
   _CropHandleSide _hitCropHandle(Offset localPoint) {


### PR DESCRIPTION
This fixes #5 

By calling [`ensureVisualUpdate`](https://docs.flutter.io/flutter/scheduler/SchedulerBinding/ensureVisualUpdate.html) we can ensure that the post render function will be called.
But a new frame is only created when no other new frame is requested.