### PR TITLE
 Fixed image rotation bug after cropping

### DIFF
--- a/ios/Classes/ImageCropPlugin.m
+++ b/ios/Classes/ImageCropPlugin.m
@@ -57,9 +57,15 @@
                                        details:nil]);
             return;
         }
+
+        CFDictionaryRef options = (__bridge CFDictionaryRef) @{
+                                                               (id) kCGImageSourceCreateThumbnailWithTransform: @YES,
+                                                               (id) kCGImageSourceCreateThumbnailFromImageAlways: @YES
+                                                               };
+
+        CGImageRef image = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, options);
         
-        CGImageRef image = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
-        
+
         if (image == NULL) {
             result([FlutterError errorWithCode:@"INVALID"
                                        message:@"Image cannot be opened"


### PR DESCRIPTION
Changed method **CGImageSourceCreateImageAtIndex** to **CGImageSourceCreateThumbnailAtIndex**, with **CFDictionaryRef** contains key **kCGImageSourceCreateThumbnailWithTransform : @YES**. 

Without transform key image gets rotated by 90 degree