### PR TITLE
Image rotation fix

### DIFF
--- a/android/src/main/java/com/lykhonis/imagecrop/ImageCropPlugin.java
+++ b/android/src/main/java/com/lykhonis/imagecrop/ImageCropPlugin.java
@@ -409,11 +409,11 @@ public final class ImageCropPlugin implements MethodCallHandler, PluginRegistry.
         }
 
         int getHeight() {
-            return isFlippedDimensions() ? width : height;
+            return (isFlippedDimensions() && degrees != 180) ? width : height;
         }
 
         int getWidth() {
-            return isFlippedDimensions() ? height : width;
+            return (isFlippedDimensions() && degrees != 180) ? height : width;
         }
 
         int getDegrees() {
@@ -421,7 +421,7 @@ public final class ImageCropPlugin implements MethodCallHandler, PluginRegistry.
         }
 
         boolean isFlippedDimensions() {
-            return degrees == 90 || degrees == 270;
+            return degrees == 90 || degrees == 270  || degrees == 180;
         }
 
         public boolean isRotated() {


### PR DESCRIPTION
The image is flipped upside down when cropped on an Android 10 operating system device.
This small improvements solved issue for me.