### PR TITLE
new: backgroundColor parameter

### DIFF
--- a/lib/image_crop.dart
+++ b/lib/image_crop.dart
@@ -6,7 +6,7 @@ import 'dart:math';
 import 'dart:ui' as ui;
 
 import 'package:flutter/gestures.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 part 'src/image_crop.dart';

--- a/lib/src/crop.dart
+++ b/lib/src/crop.dart
@@ -9,6 +9,8 @@ const _kCropHandleColor = Color.fromRGBO(0xd0, 0xd0, 0xd0, 1.0);
 const _kCropHandleSize = 10.0;
 const _kCropHandleHitSize = 48.0;
 const _kCropMinFraction = 0.1;
+const _kCropBackgroundColor =
+    Color.fromRGBO(0x0, 0x0, 0x0, _kCropOverlayInactiveOpacity);
 
 enum _CropAction { none, moving, cropping, scaling }
 
@@ -21,6 +23,11 @@ class Crop extends StatefulWidget {
   final bool alwaysShowGrid;
   final ImageErrorListener? onImageError;
 
+  /// Specifies [backgroundColor] to set the color of the mask that hide the cropped areas
+  ///
+  /// Defaults to [_kCropBackgroundColor]
+  final Color backgroundColor;
+
   const Crop({
     Key? key,
     required this.image,
@@ -28,6 +35,7 @@ class Crop extends StatefulWidget {
     this.maximumScale = 2.0,
     this.alwaysShowGrid = false,
     this.onImageError,
+    this.backgroundColor = _kCropBackgroundColor,
   }) : super(key: key);
 
   Crop.file(
@@ -38,6 +46,7 @@ class Crop extends StatefulWidget {
     this.maximumScale = 2.0,
     this.alwaysShowGrid = false,
     this.onImageError,
+    this.backgroundColor = _kCropBackgroundColor,
   })  : image = FileImage(file, scale: scale),
         super(key: key);
 
@@ -50,6 +59,7 @@ class Crop extends StatefulWidget {
     this.maximumScale = 2.0,
     this.alwaysShowGrid = false,
     this.onImageError,
+    this.backgroundColor = _kCropBackgroundColor,
   })  : image = AssetImage(assetName, bundle: bundle, package: package),
         super(key: key);
 
@@ -193,6 +203,7 @@ class CropState extends State<Crop> with TickerProviderStateMixin, Drag {
                 area: _area,
                 scale: _scale,
                 active: _activeController.value,
+                backgroundColor: widget.backgroundColor,
               ),
             ),
           ),
@@ -625,6 +636,7 @@ class _CropPainter extends CustomPainter {
   final Rect area;
   final double scale;
   final double active;
+  final Color backgroundColor;
 
   _CropPainter({
     required this.image,
@@ -633,6 +645,7 @@ class _CropPainter extends CustomPainter {
     required this.area,
     required this.scale,
     required this.active,
+    required this.backgroundColor,
   });
 
   @override
@@ -680,12 +693,9 @@ class _CropPainter extends CustomPainter {
       canvas.restore();
     }
 
-    paint.color = Color.fromRGBO(
-        0x0,
-        0x0,
-        0x0,
+    paint.color = backgroundColor.withOpacity(
         _kCropOverlayActiveOpacity * active +
-            _kCropOverlayInactiveOpacity * (1.0 - active));
+            backgroundColor.opacity * (1.0 - active));
     final boundaries = Rect.fromLTWH(
       rect.width * area.left,
       rect.height * area.top,


### PR DESCRIPTION
new `backgroundColor` parameter to custom the crop mask color, if not set the default color (black) is used.
the opacity on active/inactive is not changed.

| before PR | after PR colors set to gray |
| -- | -- |
| <video src="https://user-images.githubusercontent.com/22376981/208070840-532acc33-8621-469a-886d-318e1d568e29.mov" /> | <video src="https://user-images.githubusercontent.com/22376981/208071126-81394358-9e0b-4b18-8adc-6ba67d6af30c.mov" /> |



