### PR TITLE
add: placeholderWidget parameter

### DIFF
--- a/lib/src/crop.dart
+++ b/lib/src/crop.dart
@@ -24,6 +24,9 @@ class Crop extends StatefulWidget {
   /// Specifies [placeholderWidget] to display a [Widget] while the image is loading
   final Widget? placeholderWidget;
 
+  /// Function called when the image or the view is recomputed
+  final Function(bool isReady)? onLoading;
+
   const Crop({
     Key? key,
     required this.image,
@@ -32,6 +35,7 @@ class Crop extends StatefulWidget {
     this.alwaysShowGrid = false,
     this.onImageError,
     this.placeholderWidget,
+    this.onLoading,
   }) : super(key: key);
 
   Crop.file(
@@ -43,6 +47,7 @@ class Crop extends StatefulWidget {
     this.alwaysShowGrid = false,
     this.onImageError,
     this.placeholderWidget,
+    this.onLoading,
   })  : image = FileImage(file, scale: scale),
         super(key: key);
 
@@ -56,6 +61,7 @@ class Crop extends StatefulWidget {
     this.alwaysShowGrid = false,
     this.onImageError,
     this.placeholderWidget,
+    this.onLoading,
   })  : image = AssetImage(assetName, bundle: bundle, package: package),
         super(key: key);
 
@@ -162,7 +168,14 @@ class CropState extends State<Crop> with TickerProviderStateMixin, Drag {
     }
   }
 
+  void _onLoading(bool isLoading) {
+    if (widget.onLoading != null) {
+      widget.onLoading!(isLoading);
+    }
+  }
+
   void _getImage() {
+    _onLoading(false);
     widget.image.evict();
     final oldImageStream = _imageStream;
     final newImageStream =
@@ -335,6 +348,7 @@ class CropState extends State<Crop> with TickerProviderStateMixin, Drag {
           viewWidth,
           viewHeight,
         );
+        _onLoading(true);
       });
     });
 


### PR DESCRIPTION
- new `placeholderWidget` parameter to display a widget when the image is null
- new `onLoading` function parameter to be aware when the crop area is ready to be used

also fixed an issue where switching image causes an exception (#85)
```
════════ Exception caught by image resource service ════════════════════════════
The following assertion was thrown by a synchronously-called image listener:
Cannot get size during build.

The size of this render object has not yet been determined because the framework is still in the process of building widgets, which means the render tree for this frame has not yet been determined. The size getter should only be called from paint callbacks or interaction event handlers (e.g. gesture callbacks).
```

## example

here is a video showing how a thumbnail and a loader can be used as placeholder
<video src="https://user-images.githubusercontent.com/22376981/208072364-ab8bf03d-ba58-4e66-a127-72dd8779c4bf.mov" />