### PR TITLE
add: initialize view programmatically

### DIFF
--- a/lib/src/crop.dart
+++ b/lib/src/crop.dart
@@ -14,12 +14,28 @@ enum _CropAction { none, moving, cropping, scaling }
 
 enum _CropHandleSide { none, topLeft, topRight, bottomLeft, bottomRight }
 
+/// Model containing all the internal parameters of the [Crop] widget
+class CropInternal {
+  final Rect view, area;
+  final double ratio, scale;
+
+  const CropInternal({
+    required this.view,
+    required this.area,
+    required this.ratio,
+    required this.scale,
+  });
+}
+
 class Crop extends StatefulWidget {
   final ImageProvider image;
   final double? aspectRatio;
   final double maximumScale;
   final bool alwaysShowGrid;
   final ImageErrorListener? onImageError;
+
+  /// To initialize the crop view with data programmatically
+  final CropInternal? initialParam;
 
   const Crop({
     Key? key,
@@ -28,6 +44,7 @@ class Crop extends StatefulWidget {
     this.maximumScale = 2.0,
     this.alwaysShowGrid = false,
     this.onImageError,
+    this.initialParam,
   }) : super(key: key);
 
   Crop.file(
@@ -38,6 +55,7 @@ class Crop extends StatefulWidget {
     this.maximumScale = 2.0,
     this.alwaysShowGrid = false,
     this.onImageError,
+    this.initialParam,
   })  : image = FileImage(file, scale: scale),
         super(key: key);
 
@@ -50,6 +68,7 @@ class Crop extends StatefulWidget {
     this.maximumScale = 2.0,
     this.alwaysShowGrid = false,
     this.onImageError,
+    this.initialParam,
   })  : image = AssetImage(assetName, bundle: bundle, package: package),
         super(key: key);
 
@@ -101,6 +120,11 @@ class CropState extends State<Crop> with TickerProviderStateMixin, Drag {
 
   // Counting pointers(number of user fingers on screen)
   int pointers = 0;
+
+  /// Returns the internal parameters of the state
+  /// can be provided using [initialParam] to initialize the view to the same state
+  CropInternal get internalParameters =>
+      CropInternal(view: _view, area: _area, scale: _scale, ratio: _ratio);
 
   @override
   void initState() {
@@ -306,6 +330,16 @@ class CropState extends State<Crop> with TickerProviderStateMixin, Drag {
 
       setState(() {
         _image = image;
+
+        // initialize internal parameters if exists
+        if (widget.initialParam != null) {
+          _view = widget.initialParam!.view;
+          _area = widget.initialParam!.area;
+          _scale = widget.initialParam!.scale;
+          _ratio = widget.initialParam!.ratio;
+          return;
+        }
+
         _scale = imageInfo.scale;
         _ratio = max(
           boundaries.width / image.width,

--- a/lib/src/crop.dart
+++ b/lib/src/crop.dart
@@ -17,12 +17,11 @@ enum _CropHandleSide { none, topLeft, topRight, bottomLeft, bottomRight }
 /// Model containing all the internal parameters of the [Crop] widget
 class CropInternal {
   final Rect view, area;
-  final double ratio, scale;
+  final double scale;
 
   const CropInternal({
     required this.view,
     required this.area,
-    required this.ratio,
     required this.scale,
   });
 }
@@ -124,7 +123,7 @@ class CropState extends State<Crop> with TickerProviderStateMixin, Drag {
   /// Returns the internal parameters of the state
   /// can be provided using [initialParam] to initialize the view to the same state
   CropInternal get internalParameters =>
-      CropInternal(view: _view, area: _area, scale: _scale, ratio: _ratio);
+      CropInternal(view: _view, area: _area, scale: _scale);
 
   @override
   void initState() {
@@ -331,20 +330,20 @@ class CropState extends State<Crop> with TickerProviderStateMixin, Drag {
       setState(() {
         _image = image;
 
+        _ratio = max(
+          boundaries.width / image.width,
+          boundaries.height / image.height,
+        );
+
         // initialize internal parameters if exists
         if (widget.initialParam != null) {
           _view = widget.initialParam!.view;
           _area = widget.initialParam!.area;
           _scale = widget.initialParam!.scale;
-          _ratio = widget.initialParam!.ratio;
           return;
         }
 
         _scale = imageInfo.scale;
-        _ratio = max(
-          boundaries.width / image.width,
-          boundaries.height / image.height,
-        );
 
         final viewWidth = boundaries.width / (image.width * _scale * _ratio);
         final viewHeight = boundaries.height / (image.height * _scale * _ratio);


### PR DESCRIPTION
Fix #88.

new `initialParam` argument, to initialize the crop view programmatically.
current crop parameters can be stored using `CropInternal` model that can accessed from `CropState`.