### PR TITLE
Removed extends Drag, not compatible with Dart 3 & Flutter 3.10

### DIFF
--- a/lib/src/crop.dart
+++ b/lib/src/crop.dart
@@ -60,7 +60,7 @@ class Crop extends StatefulWidget {
       context.findAncestorStateOfType<CropState>();
 }
 
-class CropState extends State<Crop> with TickerProviderStateMixin, Drag {
+class CropState extends State<Crop> with TickerProviderStateMixin {
   final _surfaceKey = GlobalKey();
 
   late final AnimationController _activeController;


### PR DESCRIPTION
The CropState extends both State and Drag, but Dart 3 & Flutter 3.10, the class 'Drag' can't be used as a mixin because it's neither a mixin class nor a mixin.